### PR TITLE
Add Support for the Group Tools Mode

### DIFF
--- a/b2/src/main/java/au/edu/bond/classgroups/dao/BbGroupDAO.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/dao/BbGroupDAO.java
@@ -20,6 +20,7 @@ import java.util.Set;
 public class BbGroupDAO {
 
     GroupDbLoader groupDbLoader;
+    private GroupDbPersister groupDbPersister;
     CourseGroupManager courseGroupManager;
 
     public Group getById(Id id) throws PersistenceException {
@@ -38,8 +39,8 @@ public class BbGroupDAO {
         return getByCourseId(getIdFromLong(id));
     }
 
-    public void createOrUpdate(Group group) {
-        getCourseGroupManager().persistGroup(group);
+    public void createOrUpdate(Group group) throws PersistenceException, ValidationException {
+        getGroupDbPersister().persist(group);
     }
 
     public void delete(Id id) {
@@ -72,6 +73,11 @@ public class BbGroupDAO {
         return courseGroupManager;
     }
 
+    private GroupDbPersister getGroupDbPersister() throws PersistenceException {
+        if (groupDbPersister == null) {
+            groupDbPersister = GroupDbPersister.Default.getInstance();
+        }
 
-
+        return groupDbPersister;
+    }
 }

--- a/b2/src/main/java/au/edu/bond/classgroups/dao/BbGroupDAO.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/dao/BbGroupDAO.java
@@ -2,14 +2,15 @@ package au.edu.bond.classgroups.dao;
 
 import blackboard.data.ValidationException;
 import blackboard.data.course.Group;
+import blackboard.data.course.GroupMembership;
 import blackboard.persist.Id;
 import blackboard.persist.PersistenceException;
 import blackboard.persist.course.GroupDbLoader;
 import blackboard.persist.course.GroupDbPersister;
-import blackboard.platform.course.CourseGroupManager;
-import blackboard.platform.course.CourseGroupManagerFactory;
+import blackboard.persist.course.GroupMembershipDbPersister;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -19,7 +20,7 @@ public class BbGroupDAO {
 
     private GroupDbLoader groupDbLoader;
     private GroupDbPersister groupDbPersister;
-    private CourseGroupManager courseGroupManager;
+    private GroupMembershipDbPersister groupMembershipDbPersister;
 
     public Group getById(Id id) throws PersistenceException {
         return getGroupDbLoader().loadById(id);
@@ -37,12 +38,32 @@ public class BbGroupDAO {
         getGroupDbPersister().persist(group);
     }
 
-    public void delete(Id id) {
-        getCourseGroupManager().deleteGroup(id);
+    public void delete(Id id) throws PersistenceException {
+        getGroupDbPersister().deleteById(id);
     }
 
-    public void createOrUpdate(Group group, Set<Id> courseMembershipIds) {
-        getCourseGroupManager().persistGroupAndEnroll(group, courseMembershipIds);
+    public void createOrUpdate(Group group, Set<Id> courseMembershipIds) throws PersistenceException, ValidationException {
+        getGroupDbPersister().persist(group);
+
+        // persist enrolments
+        Id groupId = group.getId();
+
+        List<GroupMembership> currentGroupMembers = group.getGroupMemberships();
+
+        // delete any current members that are no longer in the group
+        for (GroupMembership currentGroupMember : currentGroupMembers) {
+            if (!courseMembershipIds.contains(currentGroupMember.getCourseMembershipId())) {
+                getGroupMembershipDbPersister().deleteById(currentGroupMember.getCourseMembershipId());
+            }
+        }
+
+        // update or insert members
+        for (Id courseMembershipId : courseMembershipIds) {
+            GroupMembership groupMembership = new GroupMembership();
+            groupMembership.setGroupId(groupId);
+            groupMembership.setCourseMembershipId(courseMembershipId);
+            getGroupMembershipDbPersister().persist(groupMembership);
+        }
     }
 
     private Id getIdFromLong(long id) {
@@ -56,18 +77,19 @@ public class BbGroupDAO {
         return groupDbLoader;
     }
 
-    private CourseGroupManager getCourseGroupManager() {
-        if(courseGroupManager == null) {
-            courseGroupManager = CourseGroupManagerFactory.getInstance();
-        }
-        return courseGroupManager;
-    }
-
     private GroupDbPersister getGroupDbPersister() throws PersistenceException {
         if (groupDbPersister == null) {
             groupDbPersister = GroupDbPersister.Default.getInstance();
         }
 
         return groupDbPersister;
+    }
+
+    private GroupMembershipDbPersister getGroupMembershipDbPersister() throws PersistenceException {
+        if (groupMembershipDbPersister == null) {
+            groupMembershipDbPersister = GroupMembershipDbPersister.Default.getInstance();
+        }
+
+        return groupMembershipDbPersister;
     }
 }

--- a/b2/src/main/java/au/edu/bond/classgroups/dao/BbGroupDAO.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/dao/BbGroupDAO.java
@@ -1,7 +1,6 @@
 package au.edu.bond.classgroups.dao;
 
 import blackboard.data.ValidationException;
-import blackboard.data.course.Course;
 import blackboard.data.course.Group;
 import blackboard.persist.Id;
 import blackboard.persist.PersistenceException;
@@ -9,7 +8,6 @@ import blackboard.persist.course.GroupDbLoader;
 import blackboard.persist.course.GroupDbPersister;
 import blackboard.platform.course.CourseGroupManager;
 import blackboard.platform.course.CourseGroupManagerFactory;
-import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.Set;
@@ -19,9 +17,9 @@ import java.util.Set;
  */
 public class BbGroupDAO {
 
-    GroupDbLoader groupDbLoader;
+    private GroupDbLoader groupDbLoader;
     private GroupDbPersister groupDbPersister;
-    CourseGroupManager courseGroupManager;
+    private CourseGroupManager courseGroupManager;
 
     public Group getById(Id id) throws PersistenceException {
         return getGroupDbLoader().loadById(id);
@@ -35,10 +33,6 @@ public class BbGroupDAO {
         return getGroupDbLoader().loadGroupsAndSetsByCourseId(id);
     }
 
-    public Collection<Group> getByCourseId(long id) throws PersistenceException {
-        return getByCourseId(getIdFromLong(id));
-    }
-
     public void createOrUpdate(Group group) throws PersistenceException, ValidationException {
         getGroupDbPersister().persist(group);
     }
@@ -47,26 +41,22 @@ public class BbGroupDAO {
         getCourseGroupManager().deleteGroup(id);
     }
 
-    public void delete(long id) {
-        delete(getIdFromLong(id));
-    }
-
     public void createOrUpdate(Group group, Set<Id> courseMembershipIds) {
         getCourseGroupManager().persistGroupAndEnroll(group, courseMembershipIds);
     }
 
-    public Id getIdFromLong(long id) {
+    private Id getIdFromLong(long id) {
         return Id.toId(Group.DATA_TYPE, id);
     }
 
-    public GroupDbLoader getGroupDbLoader() throws PersistenceException {
+    private GroupDbLoader getGroupDbLoader() throws PersistenceException {
         if(groupDbLoader == null) {
             groupDbLoader = GroupDbLoader.Default.getInstance();
         }
         return groupDbLoader;
     }
 
-    public CourseGroupManager getCourseGroupManager() {
+    private CourseGroupManager getCourseGroupManager() {
         if(courseGroupManager == null) {
             courseGroupManager = CourseGroupManagerFactory.getInstance();
         }

--- a/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
@@ -9,17 +9,20 @@ import au.edu.bond.classgroups.model.Member;
 import au.edu.bond.classgroups.service.*;
 import au.edu.bond.classgroups.util.EqualityUtil;
 import blackboard.base.FormattedText;
+import blackboard.data.ValidationException;
 import blackboard.data.course.AvailableGroupTool;
 import blackboard.data.course.Course;
 import blackboard.data.course.CourseMembership;
 import blackboard.data.course.GroupMembership;
 import blackboard.data.user.User;
 import blackboard.persist.Id;
+import blackboard.persist.PersistenceException;
 import blackboard.persist.PkId;
 import com.alltheducks.configutils.service.ConfigurationService;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.apache.commons.lang.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.persistence.NoResultException;
@@ -429,9 +432,10 @@ public class BbGroupManager implements GroupManager {
 
             try {
                 bbGroupService.createOrUpdate(bbGroupSet);
-            } catch (ExecutionException e) {
+            } catch (ExecutionException | PersistenceException | ValidationException e) {
                 taskLogger.error(resourceService.getLocalisationString(
                         "bond.classgroups.error.groupsetexecution", title, courseId), e);
+
                 return null;
             }
         }

--- a/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
@@ -9,18 +9,13 @@ import au.edu.bond.classgroups.model.Member;
 import au.edu.bond.classgroups.service.*;
 import au.edu.bond.classgroups.util.EqualityUtil;
 import blackboard.base.FormattedText;
-import blackboard.data.ValidationException;
 import blackboard.data.course.AvailableGroupTool;
 import blackboard.data.course.Course;
 import blackboard.data.course.CourseMembership;
 import blackboard.data.course.GroupMembership;
 import blackboard.data.user.User;
 import blackboard.persist.Id;
-import blackboard.persist.KeyNotFoundException;
-import blackboard.persist.PersistenceException;
 import blackboard.persist.PkId;
-import blackboard.platform.course.CourseGroupManager;
-import blackboard.platform.course.CourseGroupManagerFactory;
 import com.alltheducks.configutils.service.ConfigurationService;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -54,7 +49,7 @@ public class BbGroupManager implements GroupManager {
     private ResourceService resourceService;
 
     @Override
-    public Status syncGroup(Group group, TaskLogger taskLogger) {
+    public Status syncGroup(final Group group, final TaskLogger taskLogger) {
         Configuration configuration = configurationService.loadConfiguration();
         Id courseId;
         try {
@@ -134,16 +129,18 @@ public class BbGroupManager implements GroupManager {
 
             bbGroup.setIsAvailable(calculateAvailability(group, configuration));
 
+            provisionGroupTools(group, bbGroup);
+
             updateGroupSet(bbGroup, group, configuration, taskLogger);
 
             status = Status.CREATED;
 
-            if(configuration.getLoggingLevel().equals(Configuration.LoggingLevel.DEBUG)) {
+            if (configuration.getLoggingLevel().equals(Configuration.LoggingLevel.DEBUG)) {
                 taskLogger.info(resourceService.getLocalisationString(
                         "bond.classgroups.info.creatinggroup", group.getGroupId(), group.getTitle()));
             }
         } else {
-            if(configuration.getLoggingLevel().equals(Configuration.LoggingLevel.DEBUG)) {
+            if (configuration.getLoggingLevel().equals(Configuration.LoggingLevel.DEBUG)) {
                 taskLogger.info(resourceService.getLocalisationString(
                         "bond.classgroups.info.updatinggroup", group.getGroupId(), group.getTitle()));
             }
@@ -164,33 +161,12 @@ public class BbGroupManager implements GroupManager {
                     status = Status.UPDATED;
                 }
             }
-        }
 
-        final List<AvailableGroupTool> remainingTools = Lists.newArrayList(bbGroup.getAvailableTools(true));
-        final Collection<String> tools = (group.getTools() != null) ? group.getTools() : configuration.getDefaultTools();
-        boolean withForum = false;
-        if (tools != null) {
-            toolsLoop:
-            for (String tool : tools) {
-                if(tool.equalsIgnoreCase("discussion_board")) {
-                    withForum = true;
-                }
-                for (int i = 0; i < remainingTools.size(); i++) {
-                    final AvailableGroupTool currentTool = remainingTools.get(i);
-                    if (currentTool.getApplicationHandle().equals(tool)) {
-                        remainingTools.remove(i);
-                        continue toolsLoop;
-                    }
-                }
-
-                bbGroup.addAvailableTool(tool);
+            if (configuration.getToolsMode() == Configuration.ToolsMode.READD || configuration.getToolsMode() == Configuration.ToolsMode.SYNC) {
+                provisionGroupTools(group, bbGroup);
+                status = Status.UPDATED;
             }
         }
-        for (AvailableGroupTool remainingTool : remainingTools) {
-            bbGroup.removeAvailableTool(remainingTool.getApplicationHandle());
-        }
-
-        bbGroup.setWithForum(withForum);
 
         final List<GroupMembership> groupMemberships = bbGroup.getGroupMemberships();
         HashSet<Id> existingGroupMembers = Sets.newHashSetWithExpectedSize(groupMemberships.size());
@@ -200,14 +176,16 @@ public class BbGroupManager implements GroupManager {
 
         final Collection<Member> members = group.getMembers();
         final Set<String> feedMembers = Sets.newHashSetWithExpectedSize(members != null ? members.size() : 1);
-        if(members != null) {
+        if (members != null) {
             for (Member member : members) {
                 feedMembers.add(member.getUserId());
             }
         }
-        if(group.getLeaderId() != null && !group.getLeaderId().isEmpty()) {
+
+        if (group.getLeaderId() != null && !group.getLeaderId().isEmpty()) {
             feedMembers.add(group.getLeaderId());
         }
+
         Set<Id> memberIds = new HashSet<>();
 
         for (String feedMember : feedMembers) {
@@ -243,30 +221,32 @@ public class BbGroupManager implements GroupManager {
 
             final Id membershipId = membership.getId();
             final boolean foundInExisting = existingGroupMembers.remove(membershipId);
-            if(!foundInExisting) {
+
+            if (!foundInExisting) {
                 status = Status.UPDATED;
             }
 
             memberIds.add(membershipId);
         }
 
-        if(!existingGroupMembers.isEmpty()) {
+        if (!existingGroupMembers.isEmpty()) {
             status = Status.UPDATED;
         }
 
         if (status == Status.CREATED || status == Status.UPDATED) {
             // Persist the group.
-            if(configuration.getLoggingLevel().equals(Configuration.LoggingLevel.DEBUG)) {
-                if(status == Status.CREATED) {
+            if (configuration.getLoggingLevel().equals(Configuration.LoggingLevel.DEBUG)) {
+                if (status == Status.CREATED) {
                     taskLogger.info(resourceService.getLocalisationString(
                             "bond.classgroups.info.creatinggroupdebug",
                             group.getGroupId(), group.getCourseId(), bbGroup.getTitle(), memberIds.size()));
-                } else if (status == Status.UPDATED) {
+                } else {
                     taskLogger.info(resourceService.getLocalisationString(
                             "bond.classgroups.info.updatinggroupdebug",
                             group.getGroupId(), bbGroup.getId().toExternalString(), group.getCourseId(), courseId.toExternalString(), bbGroup.getTitle(), memberIds.size()));
                 }
             }
+
             try {
                 bbGroupService.createOrUpdate(bbGroup, memberIds);
             } catch (ExecutionException e) {
@@ -308,13 +288,49 @@ public class BbGroupManager implements GroupManager {
         return status;
     }
 
-    boolean calculateAvailability(Group group, Configuration configuration) {
-        return (group.getAvailable() != null) ? group.getAvailable() :
-                (configuration.getDefaultAvailability() == Configuration.GroupAvailability.AVAILABLE);
+    private void provisionGroupTools(final Group group, final blackboard.data.course.Group bbGroup) {
+        Configuration configuration = configurationService.loadConfiguration();
+        final List<AvailableGroupTool> remainingTools = Lists.newArrayList(bbGroup.getAvailableTools(true));
+        final Collection<String> tools = (group.getTools() != null) ? group.getTools() : configuration.getDefaultTools();
+        boolean withForum = false;
+
+        if (tools != null) {
+            toolsLoop:
+            for (String tool : tools) {
+                if (tool.equalsIgnoreCase("discussion_board")) {
+                    withForum = true;
+                }
+
+                for (int i = 0; i < remainingTools.size(); i++) {
+                    final AvailableGroupTool currentTool = remainingTools.get(i);
+
+                    if (currentTool.getApplicationHandle().equals(tool)) {
+                        remainingTools.remove(i);
+                        continue toolsLoop;
+                    }
+                }
+
+                bbGroup.addAvailableTool(tool);
+            }
+        }
+
+        if (configuration.getToolsMode() == Configuration.ToolsMode.SYNC) {
+            for (AvailableGroupTool remainingTool : remainingTools) {
+                bbGroup.removeAvailableTool(remainingTool.getApplicationHandle());
+            }
+        }
+
+        bbGroup.setWithForum(withForum);
     }
 
-    private boolean updateFeedLeader(GroupExtension ext, Group group, Id courseId, Configuration configuration, TaskLogger taskLogger) {
-        User user = null;
+    private boolean calculateAvailability(final Group group, final Configuration configuration) {
+        return group.getAvailable() != null
+            ? group.getAvailable()
+            : (configuration.getDefaultAvailability() == Configuration.GroupAvailability.AVAILABLE);
+    }
+
+    private boolean updateFeedLeader(final GroupExtension ext, final Group group, final Id courseId, final Configuration configuration, final TaskLogger taskLogger) {
+        User user;
         CourseMembership courseMembership = null;
 
         if (group.getLeaderId() != null) {
@@ -347,7 +363,7 @@ public class BbGroupManager implements GroupManager {
         if (courseMembership != null) {
             courseMembershipId = courseMembership.getId();
         }
-        boolean changed = !EqualityUtil.nullSafeEquals(existingFeedId, courseMembershipId);//(existingFeedId == null ? courseMembershipId != null : !existingFeedId.equals(courseMembershipId));
+        boolean changed = !EqualityUtil.nullSafeEquals(existingFeedId, courseMembershipId);
 
         if (!changed) {
             return false;
@@ -366,7 +382,7 @@ public class BbGroupManager implements GroupManager {
         return true;
     }
 
-    private boolean updateGroupSet(blackboard.data.course.Group bbGroup, Group group, Configuration configuration, TaskLogger taskLogger) {
+    private boolean updateGroupSet(final blackboard.data.course.Group bbGroup, final Group group, final Configuration configuration, final TaskLogger taskLogger) {
         if (bbGroup.getSetId() == null && group.getGroupSet() == null) {
             return false;
         }
@@ -385,15 +401,17 @@ public class BbGroupManager implements GroupManager {
         return false;
     }
 
-    private blackboard.data.course.Group getOrCreateGroupSet(String title, Id courseId, Configuration configuration, TaskLogger taskLogger) {
-        if(title == null || title.isEmpty()) {
+    private blackboard.data.course.Group getOrCreateGroupSet(final String title, final Id courseId, final Configuration configuration, final TaskLogger taskLogger) {
+        if (title == null || title.isEmpty()) {
             return null;
         }
 
         blackboard.data.course.Group bbGroupSet = null;
+
         try {
             bbGroupSet = bbGroupService.getByTitleAndCourseId(title, courseId);
         } catch (ExecutionException ignored) {
+
         }
 
         if (bbGroupSet == null) {
@@ -419,69 +437,5 @@ public class BbGroupManager implements GroupManager {
         }
 
         return bbGroupSet;
-    }
-
-    public BbGroupService getBbGroupService() {
-        return bbGroupService;
-    }
-
-    public void setBbGroupService(BbGroupService bbGroupService) {
-        this.bbGroupService = bbGroupService;
-    }
-
-    public GroupExtensionService getGroupExtensionService() {
-        return groupExtensionService;
-    }
-
-    public void setGroupExtensionService(GroupExtensionService groupExtensionService) {
-        this.groupExtensionService = groupExtensionService;
-    }
-
-    public BbCourseService getBbCourseService() {
-        return bbCourseService;
-    }
-
-    public void setBbCourseService(BbCourseService bbCourseService) {
-        this.bbCourseService = bbCourseService;
-    }
-
-    public BbUserService getBbUserService() {
-        return bbUserService;
-    }
-
-    public void setBbUserService(BbUserService bbUserService) {
-        this.bbUserService = bbUserService;
-    }
-
-    public BbCourseMembershipService getBbCourseMembershipService() {
-        return bbCourseMembershipService;
-    }
-
-    public void setBbCourseMembershipService(BbCourseMembershipService bbCourseMembershipService) {
-        this.bbCourseMembershipService = bbCourseMembershipService;
-    }
-
-    public ConfigurationService<Configuration> getConfigurationService() {
-        return configurationService;
-    }
-
-    public void setConfigurationService(ConfigurationService<Configuration> configurationService) {
-        this.configurationService = configurationService;
-    }
-
-    public GroupTitleService getGroupTitleService() {
-        return groupTitleService;
-    }
-
-    public void setGroupTitleService(GroupTitleService groupTitleService) {
-        this.groupTitleService = groupTitleService;
-    }
-
-    public ResourceService getResourceService() {
-        return resourceService;
-    }
-
-    public void setResourceService(ResourceService resourceService) {
-        this.resourceService = resourceService;
     }
 }

--- a/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
@@ -252,7 +252,7 @@ public class BbGroupManager implements GroupManager {
 
             try {
                 bbGroupService.createOrUpdate(bbGroup, memberIds);
-            } catch (ExecutionException e) {
+            } catch (ExecutionException | PersistenceException | ValidationException e) {
                 taskLogger.warning(resourceService.getLocalisationString(
                         "bond.classgroups.warning.groupexecution", group.getGroupId()), e);
                 return Status.ERROR;

--- a/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
@@ -240,7 +240,7 @@ public class BbGroupManager implements GroupManager {
                     taskLogger.info(resourceService.getLocalisationString(
                             "bond.classgroups.info.creatinggroupdebug",
                             group.getGroupId(), group.getCourseId(), bbGroup.getTitle(), memberIds.size()));
-                } else {
+                } else if (status == Status.UPDATED) {
                     taskLogger.info(resourceService.getLocalisationString(
                             "bond.classgroups.info.updatinggroupdebug",
                             group.getGroupId(), bbGroup.getId().toExternalString(), group.getCourseId(), courseId.toExternalString(), bbGroup.getTitle(), memberIds.size()));

--- a/b2/src/main/java/au/edu/bond/classgroups/service/BbGroupService.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/service/BbGroupService.java
@@ -87,7 +87,7 @@ public class BbGroupService implements Cleanable {
         addGroupToCache(group);
     }
 
-    public synchronized void createOrUpdate(Group group, Set<Id> courseMembershipIds) throws ExecutionException {
+    public synchronized void createOrUpdate(Group group, Set<Id> courseMembershipIds) throws ExecutionException, PersistenceException, ValidationException {
         bbGroupDAO.createOrUpdate(group, courseMembershipIds);
         addGroupToCache(group);
     }

--- a/b2/src/main/java/au/edu/bond/classgroups/service/BbGroupService.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/service/BbGroupService.java
@@ -99,17 +99,15 @@ public class BbGroupService implements Cleanable {
 
         }
 
-        Id courseId = group.getCourseId();
-        Map<Id, Group> groupMap = byIdCache.get(courseId);
-        Map<String, Group> titleMap = byTitleCache.get(courseId);
-
-        groupMap.put(group.getId(), group);
-        titleMap.put(group.getTitle(), group);
+        addGroupToCache(group);
     }
 
     public synchronized void createOrUpdate(Group group, Set<Id> courseMembershipIds) throws ExecutionException {
         bbGroupDAO.createOrUpdate(group, courseMembershipIds);
+        addGroupToCache(group);
+    }
 
+    private void addGroupToCache(Group group) {
         Id courseId = group.getCourseId();
         Map<Id, Group> groupMap = byIdCache.get(courseId);
         Map<String, Group> titleMap = byTitleCache.get(courseId);

--- a/b2/src/main/java/au/edu/bond/classgroups/service/BbGroupService.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/service/BbGroupService.java
@@ -35,6 +35,8 @@ public class BbGroupService implements Cleanable {
                 Collection<Group> classGroups = bbGroupDAO.getByCourseId(courseId);
                 ConcurrentHashMap<Id, Group> groupMap = new ConcurrentHashMap<Id, Group>();
                 for (Group group : classGroups) {
+                    // populate the group's tools by using the getAvailableTools() function
+                    group.getAvailableTools();
                     groupMap.put(group.getId(), group);
                 }
                 return groupMap;
@@ -91,7 +93,11 @@ public class BbGroupService implements Cleanable {
     }
 
     public synchronized void createOrUpdate(Group group) throws ExecutionException {
-        bbGroupDAO.createOrUpdate(group);
+        try {
+            bbGroupDAO.createOrUpdate(group);
+        } catch (Exception e) {
+
+        }
 
         Id courseId = group.getCourseId();
         Map<Id, Group> groupMap = byIdCache.get(courseId);

--- a/b2/src/main/java/au/edu/bond/classgroups/stripes/CourseSettingsAction.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/stripes/CourseSettingsAction.java
@@ -111,11 +111,8 @@ public class CourseSettingsAction implements ActionBean {
             } else {
                 bbGroup.setTitle(groupExtension.getTitle());
             }
-            try {
-                bbGroupDAO.createOrUpdate(bbGroup);
-            } catch (Exception e) {
 
-            }
+             bbGroupDAO.createOrUpdate(bbGroup);
         }
 
         groupExtensionDAO.update(groupExtension);

--- a/b2/src/main/java/au/edu/bond/classgroups/stripes/CourseSettingsAction.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/stripes/CourseSettingsAction.java
@@ -111,7 +111,11 @@ public class CourseSettingsAction implements ActionBean {
             } else {
                 bbGroup.setTitle(groupExtension.getTitle());
             }
-            bbGroupDAO.createOrUpdate(bbGroup);
+            try {
+                bbGroupDAO.createOrUpdate(bbGroup);
+            } catch (Exception e) {
+
+            }
         }
 
         groupExtensionDAO.update(groupExtension);

--- a/b2/src/main/webapp/WEB-INF/bb-manifest.xml
+++ b/b2/src/main/webapp/WEB-INF/bb-manifest.xml
@@ -4,7 +4,7 @@
         <name value="b2.name"/>
         <handle value="ClassGroups"/>
         <description value="b2.description"/>
-        <version value="2.1.16"/>
+        <version value="2.1.17"/>
         <requires>
             <bbversion value="9.1"/>
         </requires>


### PR DESCRIPTION
There didn't appear to be any support for the Group Tools Mode section. 

![image](https://user-images.githubusercontent.com/1457058/58618280-16d38680-82ba-11e9-932e-7b6065c6b882.png)

We had selected _Create Mode_ but when submitting an update for a group and moving students from one group to another, the group's tools were modified.

On inspection of the code I couldn't see any reference to `Configuration.ToolsMode` so believe that this feature was never fully implemented.

This pull request does the following:

* Adds support for the group tools mode
* Removes the usage of the non-public API `getCourseGroupManager().persistGroup(group);`