### PR TITLE
Capture RuntimeException instead of ExecutionException

### DIFF
--- a/api/src/main/java/au/edu/bond/classgroups/groupext/GroupExtensionService.java
+++ b/api/src/main/java/au/edu/bond/classgroups/groupext/GroupExtensionService.java
@@ -6,11 +6,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -36,7 +31,7 @@ public class GroupExtensionService implements Cleanable {
         return byIdCache.get(externalId);
     }
 
-    public void create(GroupExtension groupExtension) throws ExecutionException {
+    public void create(GroupExtension groupExtension) throws RuntimeException {
         groupExtensionDAO.create(groupExtension);
         byIdCache.put(groupExtension.getExternalSystemId(), groupExtension);
     }

--- a/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
@@ -22,7 +22,6 @@ import com.alltheducks.configutils.service.ConfigurationService;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import org.apache.commons.lang.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.persistence.NoResultException;
@@ -273,7 +272,7 @@ public class BbGroupManager implements GroupManager {
         if (extNew) {
             try {
                 groupExtensionService.create(ext);
-            } catch (ExecutionException e) {
+            } catch (RuntimeException e) {
                 taskLogger.warning(resourceService.getLocalisationString(
                         "bond.classgroups.warning.failedextcreate", group.getGroupId(), courseId), e);
                 return Status.ERROR;

--- a/b2/src/main/webapp/WEB-INF/bb-manifest.xml
+++ b/b2/src/main/webapp/WEB-INF/bb-manifest.xml
@@ -4,7 +4,7 @@
         <name value="b2.name"/>
         <handle value="ClassGroups"/>
         <description value="b2.description"/>
-        <version value="2.1.17"/>
+        <version value="2.1.18"/>
         <requires>
             <bbversion value="9.1"/>
         </requires>


### PR DESCRIPTION
When running some group imports, we hit a RollbackException which crashed the import. There was nothing noted in the logs.

Upon closer inspection, it looks like the RuntimeException was not being caught higher up the stack where it should have been logged.

This pull request changes the `create` method in the `GroupExtensionService` to throw a `RuntimeException` instead of an `ExecutionException` as this type of exception is never thrown by the `create` method.