### PR TITLE
Log Message Size Fix

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'java'
-version = '2.1.15'
+version = '2.1.19'
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/api/src/main/java/au/edu/bond/classgroups/dao/LogEntryDAO.java
+++ b/api/src/main/java/au/edu/bond/classgroups/dao/LogEntryDAO.java
@@ -83,10 +83,10 @@ public class LogEntryDAO implements Closeable {
             entityManager.persist(entry);
             entityTransaction.commit();
         } catch(RuntimeException e) {
-            if(entityTransaction != null) {
+            if (entityTransaction != null) {
                 try {
                     entityTransaction.rollback();
-                } catch(RuntimeException ignored) {
+                } catch (RuntimeException ignored) {
                 }
             }
             throw e;

--- a/b2/src/main/java/au/edu/bond/classgroups/dao/BbGroupDAO.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/dao/BbGroupDAO.java
@@ -18,7 +18,6 @@ import java.util.Set;
 public class BbGroupDAO {
 
     private GroupDbLoader groupDbLoader;
-    //private GroupDbPersister groupDbPersister;
     private CourseGroupManager courseGroupManager;
 
     public Group getById(Id id) throws PersistenceException {

--- a/b2/src/main/java/au/edu/bond/classgroups/dao/BbGroupDAO.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/dao/BbGroupDAO.java
@@ -18,7 +18,7 @@ import java.util.Set;
 public class BbGroupDAO {
 
     private GroupDbLoader groupDbLoader;
-    private GroupDbPersister groupDbPersister;
+    //private GroupDbPersister groupDbPersister;
     private CourseGroupManager courseGroupManager;
 
     public Group getById(Id id) throws PersistenceException {
@@ -33,8 +33,8 @@ public class BbGroupDAO {
         return getGroupDbLoader().loadGroupsAndSetsByCourseId(id);
     }
 
-    public void createOrUpdate(Group group) throws PersistenceException, ValidationException {
-        getGroupDbPersister().persist(group);
+    public void createOrUpdate(Group group) {
+        getCourseGroupManager().persistGroup(group);
     }
 
     public void delete(Id id) {
@@ -49,25 +49,17 @@ public class BbGroupDAO {
         return Id.toId(Group.DATA_TYPE, id);
     }
 
-    private CourseGroupManager getCourseGroupManager() {
-        if(courseGroupManager == null) {
-            courseGroupManager = CourseGroupManagerFactory.getInstance();
-        }
-        return courseGroupManager;
-    }
-
-    private GroupDbLoader getGroupDbLoader() throws PersistenceException {
+    public GroupDbLoader getGroupDbLoader() throws PersistenceException {
         if(groupDbLoader == null) {
             groupDbLoader = GroupDbLoader.Default.getInstance();
         }
         return groupDbLoader;
     }
 
-    private GroupDbPersister getGroupDbPersister() throws PersistenceException {
-        if (groupDbPersister == null) {
-            groupDbPersister = GroupDbPersister.Default.getInstance();
+    private CourseGroupManager getCourseGroupManager() {
+        if(courseGroupManager == null) {
+            courseGroupManager = CourseGroupManagerFactory.getInstance();
         }
-
-        return groupDbPersister;
+        return courseGroupManager;
     }
 }

--- a/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/manager/BbGroupManager.java
@@ -252,7 +252,7 @@ public class BbGroupManager implements GroupManager {
 
             try {
                 bbGroupService.createOrUpdate(bbGroup, memberIds);
-            } catch (ExecutionException | PersistenceException | ValidationException e) {
+            } catch (ExecutionException e) {
                 taskLogger.warning(resourceService.getLocalisationString(
                         "bond.classgroups.warning.groupexecution", group.getGroupId()), e);
                 return Status.ERROR;

--- a/b2/src/main/java/au/edu/bond/classgroups/service/BbGroupService.java
+++ b/b2/src/main/java/au/edu/bond/classgroups/service/BbGroupService.java
@@ -87,7 +87,7 @@ public class BbGroupService implements Cleanable {
         addGroupToCache(group);
     }
 
-    public synchronized void createOrUpdate(Group group, Set<Id> courseMembershipIds) throws ExecutionException, PersistenceException, ValidationException {
+    public synchronized void createOrUpdate(Group group, Set<Id> courseMembershipIds) throws ExecutionException {
         bbGroupDAO.createOrUpdate(group, courseMembershipIds);
         addGroupToCache(group);
     }

--- a/b2/src/main/webapp/WEB-INF/bb-manifest.xml
+++ b/b2/src/main/webapp/WEB-INF/bb-manifest.xml
@@ -4,7 +4,7 @@
         <name value="b2.name"/>
         <handle value="ClassGroups"/>
         <description value="b2.description"/>
-        <version value="2.1.17"/>
+        <version value="2.1.19"/>
         <requires>
             <bbversion value="9.1"/>
         </requires>

--- a/b2/src/main/webapp/schema/bond-ClassGroups/schema.xml
+++ b/b2/src/main/webapp/schema/bond-ClassGroups/schema.xml
@@ -65,7 +65,7 @@
         <column name="task_pk1" data-type="int" nullable="false" />
         <column name="logged_date" data-type="datetime" nullable="false" />
         <column name="log_level" data-type="nvarchar(10)" nullable="false" />
-        <column name="message" data-type="nvarchar(255)" nullable="false" />
+        <column name="message" data-type="nvarchar(500)" nullable="false" />
         <column name="stacktrace" data-type="ntext" nullable="true" />
         <primary-key name="bond_ClassGroups_log_pk">
             <columnref name="pk1" />


### PR DESCRIPTION
We encountered an issue when running the b2 in debug mode. This was because we have very long group and course names which we can't reduce in size.

In the log table, the message field is restricted to 255 characters and we were breaching that limit. This PR increases the message field's size to 500 characters.

It also reverts some earlier changes around using non-public APIs. We have been in discussions with Blackboard about these and I think I need to implement a different approach. I will submit a new PR in a month or two once I've worked through this.

Sorry for the pretty regular PRs at the moment. As it is the start of term we are now seeing minor issues but hopefully things should die down soon. Thank you.